### PR TITLE
fix: GitHub Actions workflow for versioning and binary building

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -22,6 +22,11 @@ jobs:
       run: |
         pip install commitizen
 
+    - name: Configure Git
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
     - name: Generate Version Tag with Commitizen
       id: tag
       run: |
@@ -29,11 +34,9 @@ jobs:
         cz bump --yes
         NEW_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
         echo "New tag: $NEW_TAG"
-        echo "::set-output name=new_tag::$NEW_TAG"
+        echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
 
     - name: Create Git Tag
       if: steps.tag.outputs.new_tag != ''
       run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
         git push origin ${{ steps.tag.outputs.new_tag }}

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,10 @@ pip-freeze: .venv ## Freeze the requirements
 	. .venv/bin/activate && pip freeze > requirements.txt
 
 build-binary: pip-install ## Build a standalone binary using PyInstaller
-	. .venv/bin/activate && pip install pyinstaller && pyinstaller --onefile --name pyhooker pyhooker.py
+	. .venv/bin/activate && pip install pyinstaller && pyinstaller --onefile --name pyhooker \
+		--add-data "templates:templates" \
+		--add-data "public:public" \
+		pyhooker.py
 
 install-local: build-binary ## Install the binary locally
 	sudo cp dist/pyhooker /usr/local/bin/

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@
 
 import json
 import time
+import os
 
 import uvicorn
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
@@ -12,10 +13,14 @@ from starlette.staticfiles import StaticFiles
 
 app = FastAPI()
 
-app.mount("/static", StaticFiles(directory="./public/static"), name="static")
+# Get resource paths from environment variables or use defaults
+templates_dir = os.environ.get("TEMPLATES_DIR", "templates")
+public_dir = os.environ.get("PUBLIC_DIR", "./public")
+
+app.mount("/static", StaticFiles(directory=os.path.join(public_dir, "static")), name="static")
 
 # Directorio de plantillas
-templates = Jinja2Templates(directory="templates")
+templates = Jinja2Templates(directory=templates_dir)
 
 # Lista para almacenar las peticiones recibidas
 peticiones_recibidas = []

--- a/pyhooker.py
+++ b/pyhooker.py
@@ -6,8 +6,27 @@ PyHooker - A simple webhook receiver and inspector tool.
 import os
 import sys
 import app
+import importlib.resources
+import importlib.util
+import site
+import sys
+
+def get_resource_path(relative_path):
+    """Get the resource path, works for both development and PyInstaller."""
+    if getattr(sys, 'frozen', False):
+        # Running as a PyInstaller bundle
+        base_path = sys._MEIPASS
+    else:
+        # Running in normal Python environment
+        base_path = os.path.dirname(os.path.abspath(__file__))
+        
+    return os.path.join(base_path, relative_path)
 
 if __name__ == "__main__":
+    # Set environment variables for resource paths
+    os.environ["TEMPLATES_DIR"] = get_resource_path("templates")
+    os.environ["PUBLIC_DIR"] = get_resource_path("public")
+    
     # Print a welcome message
     print("=" * 50)
     print("PyHooker - Webhook Receiver and Inspector")


### PR DESCRIPTION
This pull request includes several changes to improve the configuration and functionality of the project. The most important changes include configuring Git in the GitHub Actions workflow, enhancing the `Makefile` to include additional data in the binary, updating the `app.py` to use environment variables for resource paths, and adding a utility function in `pyhooker.py` to handle resource paths for both development and PyInstaller environments.

Configuration and workflow improvements:

* [`.github/workflows/versioning.yml`](diffhunk://#diff-a939aacba1dba4141eda9eda616ff5e54462b324fbaebe0f8848c06964e67c68R25-L38): Configured Git user name and email globally in the GitHub Actions workflow to ensure consistent tagging and pushing of new versions.

Enhancements to the build process:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L27-R30): Modified the `build-binary` target to include additional data directories (`templates` and `public`) in the standalone binary built with PyInstaller.

Resource path management:

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L15-R23): Updated to retrieve resource paths (`templates` and `public`) from environment variables, with defaults provided. This ensures flexibility and better configuration management.
* [`pyhooker.py`](diffhunk://#diff-528dfe1feb5cfd66fa21258236dbd69f6f91e29e0ee148b64fa17437ad7a865bR9-R29): Added a utility function `get_resource_path` to determine the correct resource path for both development and PyInstaller bundle environments. This function sets environment variables for resource paths accordingly.

Minor updates:

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R5): Imported the `os` module to support the new environment variable functionality.