### PR TITLE
feat: Adds port argument to enable configure it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: all help
+PORT?=8081
 
 help: ## This beautiful help
 	@echo "Usage: make [command]"
@@ -12,7 +13,7 @@ build: pip-install ## Build the application
 run: .venv ## Run the application
 	. .venv/bin/activate && \
 	pip install -r requirements.txt && \
-	python app.py
+	python app.py --port $(PORT)
 
 .venv: ## Create a virtual environment
 	python3 -m venv .venv

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 # main.py
-
+import argparse
 import json
 import time
 
@@ -92,9 +92,13 @@ async def delete_peticiones():
     return {"message": "Todas las peticiones han sido eliminadas"}
 
 
-if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8081)
+def parser_args():
+    parser = argparse.ArgumentParser(description='Webhook receiver API')
+    parser.add_argument('--port', type=int, default=8081, help='Port to run the API')
+    args = parser.parse_args()
+    return args
 
-# Add a main function that can be called from other scripts
-def main():
-    uvicorn.run(app, host="0.0.0.0", port=8081)
+
+if __name__ == "__main__":
+    args = parser_args()
+    uvicorn.run(app, host="0.0.0.0", port=args.port)

--- a/app.py
+++ b/app.py
@@ -23,8 +23,16 @@ peticiones_recibidas = []
 # Lista de websockets conectados
 websockets_conectados = []
 
-# Iniciar el túnel ngrok en el puerto 8000
-public_url = ngrok.connect(8081).public_url
+
+def parser_args():
+    parser = argparse.ArgumentParser(description='Webhook receiver API')
+    parser.add_argument('--port', type=int, default=8081, help='Port to run the API')
+    args = parser.parse_args()
+    return args
+
+args = parser_args()
+# Iniciar el túnel ngrok en el puerto elegido
+public_url = ngrok.connect(args.port).public_url
 print(f" * Túnel ngrok establecido en {public_url}")
 
 
@@ -90,13 +98,6 @@ async def delete_peticiones():
         await websocket.send_text(data)
     
     return {"message": "Todas las peticiones han sido eliminadas"}
-
-
-def parser_args():
-    parser = argparse.ArgumentParser(description='Webhook receiver API')
-    parser.add_argument('--port', type=int, default=8081, help='Port to run the API')
-    args = parser.parse_args()
-    return args
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces changes to make the application's port configurable via a command-line argument and the `Makefile`. The most important changes include adding a default port variable to the `Makefile`, modifying the application run command to use this variable, and updating the `app.py` to parse command-line arguments for the port.

Configuration improvements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R2): Added a `PORT` variable with a default value of `8081` to allow configuration of the port.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L15-R16): Updated the `run` command to pass the `PORT` variable to the `python app.py` command.

Code enhancements in `app.py`:

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L2-R2): Imported the `argparse` module to handle command-line arguments.
* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L95-R104): Added a `parser_args` function to parse the `--port` argument and updated the main block to use the parsed port value when running the application.